### PR TITLE
fix wrong highlight groups being merged

### DIFF
--- a/lua/baleia/locations/neighbours.lua
+++ b/lua/baleia/locations/neighbours.lua
@@ -7,15 +7,9 @@ local M = {}
 ---@return boolean
 local function can_merge(previous, current)
   local on_the_same_line = current.from.line == previous.from.line
-  local in_different_lines = current.from.line == previous.from.line + 1
-
   local no_text_between_locations = current.from.column == previous.from.column + previous.style.offset
 
-  local current_location_at_start = current.from.column == 1
-  local previous_location_at_the_end = previous.to.column == nil
-
-  return (on_the_same_line and no_text_between_locations)
-    or (in_different_lines and current_location_at_start and previous_location_at_the_end)
+  return on_the_same_line and no_text_between_locations
 end
 
 ---@param previous Location


### PR DESCRIPTION
Found the line of code that had been causing wrong highlights.
![image](https://github.com/m00qek/baleia.nvim/assets/79868097/7b592703-30f0-4ed9-8e5a-b4aece840e7a)
